### PR TITLE
Rename variant names of `IconType`

### DIFF
--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -3,6 +3,6 @@ extern crate msgbox;
 use msgbox::IconType;
 
 fn main() {
-    msgbox::create("Hello Title", "Hello World!", IconType::INFO);
-    msgbox::create("Error", "Error occured at hello_world.rs:5.\nTerminating..", IconType::ERROR);
+    msgbox::create("Hello Title", "Hello World!", IconType::Info);
+    msgbox::create("Error", "Error occured at hello_world.rs:5.\nTerminating..", IconType::Error);
 }

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -1,5 +1,5 @@
 pub enum IconType {
-    ERROR,
-    INFO,
-    NONE
+    Error,
+    Info,
+    None,
 }

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -12,9 +12,9 @@ pub fn create(title:&str, content:&str, icon_type:IconType) {
     }
 
     let message_type = match icon_type {
-        IconType::ERROR => MessageType::Error,
-        IconType::INFO => MessageType::Info,
-        IconType::NONE => MessageType::Other,
+        IconType::Error => MessageType::Error,
+        IconType::Info => MessageType::Info,
+        IconType::None => MessageType::Other,
     };
 
     let dialog = MessageDialog::new(

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -72,11 +72,11 @@ impl NSAlert for id {
 
 pub fn create(title:&str, content:&str, icon_type:IconType) {
     let alert_style = match icon_type {
-        IconType::ERROR => NSAlertStyle::critical,
-        IconType::INFO => NSAlertStyle::informational,
+        IconType::Error => NSAlertStyle::critical,
+        IconType::Info => NSAlertStyle::informational,
 
         // AppKit doesn't support NSAlert without any icon
-        IconType::NONE => NSAlertStyle::informational,
+        IconType::None => NSAlertStyle::informational,
     };
 
     unsafe {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -10,9 +10,9 @@ pub fn create(title:&str, content:&str, icon_type:IconType) {
     let lp_caption: Vec<u16> = title.encode_utf16().chain(once(0)).collect();
 
     let window_type = match icon_type {
-        IconType::ERROR => MB_OK | MB_ICONERROR | MB_SYSTEMMODAL,
-        IconType::INFO => MB_OK | MB_ICONINFORMATION | MB_SYSTEMMODAL,
-        IconType::NONE => MB_OK | MB_SYSTEMMODAL,
+        IconType::Error => MB_OK | MB_ICONERROR | MB_SYSTEMMODAL,
+        IconType::Info => MB_OK | MB_ICONINFORMATION | MB_SYSTEMMODAL,
+        IconType::None => MB_OK | MB_SYSTEMMODAL,
     };
 
     unsafe {


### PR DESCRIPTION
Hi there! Thanks a ton for this crate! I noticed however, that `IconType` is not following the official Rust naming rules. So I quickly fixed that. 

