### PR TITLE
Upgrade Mac and Windows dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,5 +28,5 @@ user32-sys = "0.2.0"
 gtk = "0.4.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-cocoa = "0.14.0"
+cocoa = "0.19.0"
 objc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,7 @@ license = "MIT"
 crate-type = ["rlib", "dylib"]
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = "0.2.8"
-user32-sys = "0.2.0"
+winapi = { version = "0.3.8", features = ["winuser"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 gtk = "0.4.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,9 +33,6 @@ pub use macos::*;
  * WinAPI
  */
 #[cfg(target_os = "windows")]
-extern crate user32;
-
-#[cfg(target_os = "windows")]
 extern crate winapi;
 
 #[cfg(target_os = "windows")]

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,4 +1,4 @@
-use ::cocoa::base::{id, nil, class};
+use ::cocoa::base::{id, nil};
 use ::cocoa::foundation::NSString;
 
 use icon::IconType;
@@ -27,7 +27,7 @@ pub enum NSAlertStyle {
  */
 pub trait NSAlert: Sized {
     unsafe fn alloc(_: Self) -> id {
-        msg_send![class("NSAlert"), alloc]
+        msg_send![class!(NSAlert), alloc]
     }
 
     unsafe fn init(self) -> id;

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,10 +1,11 @@
 use icon::IconType;
 
-pub fn create(title:&str, content:&str, icon_type:IconType) {
+pub fn create(title: &str, content: &str, icon_type: IconType) {
     use std::iter::once;
     use std::ptr::null_mut;
-    use ::user32::MessageBoxW;
-    use ::winapi::winuser::{MB_OK, MB_ICONINFORMATION, MB_ICONERROR, MB_SYSTEMMODAL};
+    use winapi::um::winuser::{
+        MessageBoxW, MB_ICONERROR, MB_ICONINFORMATION, MB_OK, MB_SYSTEMMODAL,
+    };
 
     let lp_text: Vec<u16> = content.encode_utf16().chain(once(0)).collect();
     let lp_caption: Vec<u16> = title.encode_utf16().chain(once(0)).collect();
@@ -20,7 +21,7 @@ pub fn create(title:&str, content:&str, icon_type:IconType) {
             null_mut(),
             lp_text.as_ptr(),
             lp_caption.as_ptr(),
-            window_type
+            window_type,
         );
     }
 }


### PR DESCRIPTION
`cocoa` 0.14 -> 0.19 and `winapi` 0.2.8 -> 0.3.8.

One probably should update the old `gtk` dependency on Linux as well, but didn't have a Linux environment handy right now.

Would be great to have a new patch release with this published to crates.io!