### PR TITLE
Allow msgbox to be used with panic=abort.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ keywords = ["msgbox", "gui", "gtk"]
 license = "MIT"
 
 [lib]
-crate-type = ["rlib", "dylib"]
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.8", features = ["winuser"] }


### PR DESCRIPTION
As far as I can tell, this setting for msgbox (to force it to always be dynamically linked) was an artifact of the initial commit and isn't needed.  It's also the only crate (of 400+ that we use in Veloren) that doesn't work with panic=abort, which we'd like to be able to set since it can significantly decrease compile time.  This change fixes that issue.

If for some reason the old behavior is needed in some cases, I imagine we can create a separate target with that behavior.