### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,11 @@ keywords = ["msgbox", "gui", "gtk"]
 license = "MIT"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = { version = "0.3.8", features = ["winuser"] }
+winapi = { version = "^0.3.8", features = ["winuser"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
-gtk = "0.4.1"
+gtk = "0.8"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-cocoa = "0.19.0"
+cocoa = "0.19"
 objc = "0.2"


### PR DESCRIPTION
* Update gtk to latest
* Allow future semver compatible versions of winapi

Tested on Windows and Ubuntu.

cocoa dependecy is not updated because I cannot test it.