### PR TITLE
do not write error messages on console

### DIFF
--- a/src/linux.rs
+++ b/src/linux.rs
@@ -6,8 +6,7 @@ use icon::IconType;
 
 pub fn create(title:&str, content:&str, icon_type:IconType) {
     if gtk::init().is_err() {
-        println!("Failed to initialize GTK.");
-        println!("{}", content);
+        // TODO: return a result with some error type.
         return;
     }
 


### PR DESCRIPTION
This resolves partly #13 
It silently returns and keeps the console clean.
Left to do: 

* define (thiserror?) and return some error type. I am not sure, do other GTK calls return something useful to forward to the user of your library?