### PR TITLE
exclude Mac from Unix target (addendum to #15)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,14 +20,13 @@ license = "MIT"
 [dependencies]
 thiserror = "1.0.21"
 
-[target.'cfg(target_family = "unix")'.dependencies]
-glib = "0.10.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.9", features = ["winuser"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
 gtk = "0.9.2"
+glib = "0.10.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = "0.24.0"

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,4 +1,10 @@
-#[cfg(target_family = "unix")]
+#[cfg(any(
+    target_os = "linux",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd"
+))]
 use glib::error::BoolError;
 use std::fmt;
 
@@ -17,10 +23,22 @@ impl fmt::Display for IconType {
 
 #[derive(thiserror::Error, Debug)]
 pub enum MsgBoxError {
-    #[cfg(target_family = "unix")]
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    ))]
     #[error("failed to create a message box")]
     Create(#[from] BoolError),
-    #[cfg(not(target_family = "unix"))]
+    #[cfg(not(any(
+        target_os = "linux",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    )))]
     #[error("failed to create a message box")]
     Create(()),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#[cfg(target_family = "unix")]
-extern crate glib;
 extern crate thiserror;
 
 pub mod common;
@@ -16,6 +14,15 @@ pub use common::{IconType, MsgBoxError};
     target_os = "openbsd"
 ))]
 extern crate gtk;
+
+#[cfg(any(
+    target_os = "linux",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd"
+))]
+extern crate glib;
 
 #[cfg(any(
     target_os = "linux",


### PR DESCRIPTION
This is an addendum to #15 : 

> glib crate is not necessary on macOS. The linker might not include unnecessary bits in the output, but I want to avoid fetching and compiling unnecessary dependencies unless I really have to.

This commit should resolve it.

Please someone: test it on Mac!
